### PR TITLE
Updated entry for Watch and Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This can be used as a companion to [FreeCodeCamp](https://www.freecodecamp.org/)
 |   | Course | Learn Flexbox - [Flexbox.io](https://flexbox.io/) OR [Flexboxfroggy](http://flexboxfroggy.com/) |   |    |
 |   | Course | Learn Sass - [Sass-guide](http://sass-lang.com/guide) OR [Sass Tutorials](http://www.sassshop.com/#/) |   |    |
 |  | Project | Refactor the portfolio site layout and CSS using Flexbox and Sass |   |    |
-| | Course | [Watch and Code - Practical Javascript](https://watchandcode.com/p/practical-javascript) |  |    |
+| | Course | [Watch and Code](https://watchandcode.com) |  |    |
 |   | Book | [Eloquent Javascript](http://eloquentjavascript.net/) |   |    |
 |   | Project | Do FCC [Javascript Basic Algorithm Challenges](https://www.freecodecamp.org/map) |   |    |
 |  | Book | Learn DOM manipulation - [DOM Enlightenment](http://domenlightenment.com/)  |   |    |


### PR DESCRIPTION
- Updated link url because the old link no longer worked.
- Updated link text because the Practical JavaScript course has been replaced.